### PR TITLE
Linked GitHub API service to Repository model created in previous branch

### DIFF
--- a/src/app/github-api.service.ts
+++ b/src/app/github-api.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
-import { Headers, Http } from '@angular/http';
+import { Http, Response } from '@angular/http';
 
-import 'rxjs/add/operator/toPromise';
+import { Observable } from 'rxjs';
+
+import { Repository } from './repository';
 
 @Injectable()
 export class GithubApiService {
@@ -10,10 +12,31 @@ export class GithubApiService {
 
   constructor(private http: Http) { }
 
-  // Sends GET request to GitHub API to search/query for repositories 
-  getRepos(query): Promise<Object[]> {
-    return this.http.get(`${this.githubUrl}?q=${query}`)
-               .toPromise()
-               .then(response => response.json() as Object[]);
+  // Sends GET request to GitHub API to search/query for repositories, returns Observable that can be subscribed to
+  getRepos(query): Observable<Repository[]> {
+    return this.http
+        .get(`${this.githubUrl}?q=${query}`)
+        .map(mapRepos);
   }
+}
+
+function mapRepos(response:Response): Repository[]{
+  // Map data from GET request after converting it to JSON
+  return response.json().results.map(toRepo)
+}
+
+function toRepo(r:any): Repository{
+  // Process data from GitHub's API, extract the relevant data, and create a Repository model object
+  let repo = <Repository>({
+    id: r.id,
+    name: r.name,
+    owner_login: r.owner.login,
+    url: r.html_url,
+    description: r.description,
+    stargazers_count: r.stargazers_count,
+    watchers_count: r.watches_count,
+    forks: r.forks
+  });
+
+  return repo;
 }


### PR DESCRIPTION
Modified GitHub API service to include method that accesses GitHub's API and extrapolates relevant data to fit our Repository model.