### PR TITLE
Fixed bug where absence of Headers import led to problems in certain browsers

### DIFF
--- a/src/app/github-api.service.ts
+++ b/src/app/github-api.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { Http, Response, Headers } from '@angular/http';
 
 import { Observable } from 'rxjs';
 import 'rxjs/add/operator/map';


### PR DESCRIPTION
Chrome seemed to already have Headers imported (further research might need to be done) -- Safari would raise a fit without the import.. So, easy fix: import Headers from @angular/http. Both browsers seem happy about it now

👍 